### PR TITLE
Added PPID to IMAConfig

### DIFF
--- a/IMAConfig.swift
+++ b/IMAConfig.swift
@@ -23,6 +23,7 @@ import GoogleInteractiveMediaAds
     @objc public var videoBitrate = kIMAAutodetectBitrate
     @objc public var videoMimeTypes: [Any]?
     @objc public var adTagUrl: String = ""
+    @objc public var ppid: String?
     @objc public var companionView: UIView?
     @objc public var webOpenerPresentingController: UIViewController?
     /// ads request timeout interval, when ads request will take more then this time will resume content.

--- a/IMAPlugin.swift
+++ b/IMAPlugin.swift
@@ -373,6 +373,7 @@ enum IMAState: Int, StateProtocol {
         imaSettings.language = config.language
         imaSettings.enableBackgroundPlayback = config.enableBackgroundPlayback
         imaSettings.autoPlayAdBreaks = config.autoPlayAdBreaks
+        if let ppid = config.ppid { imaSettings.ppid = ppid }
         imaSettings.enableDebugMode = config.enableDebugMode
         IMAPlugin.loader = IMAAdsLoader(settings: imaSettings)
     }


### PR DESCRIPTION
Our team has frequently needed to use PPID for tracking purposes, and we have forked the IMA library as a result.

This PR adds support for PPID as an optional parameter. If a PPID is specified in the config, it will be used. If not, it won't.

Since PPID is not a required field on IMAConfig, this change is purely additive and will not affect existing codebases that rely on this framework.