### PR TITLE
FEM-2316 Expose additional IMA ad data

### DIFF
--- a/IMAExtensions.swift
+++ b/IMAExtensions.swift
@@ -35,7 +35,9 @@ extension PKAdInfo {
             adPosition: Int(ad.adPodInfo.adPosition),
             timeOffset: ad.adPodInfo.timeOffset,
             isBumper: ad.adPodInfo.isBumper,
-            podIndex: Int(ad.adPodInfo.podIndex)
-        )
+            podIndex: Int(ad.adPodInfo.podIndex),
+            vastMediaWidth: ad.vastMediaWidth,
+            vastMediaHeight: ad.vastMediaHeight,
+            vastMediaBitrate: ad.vastMediaBitrate)
     }
 }

--- a/IMAExtensions.swift
+++ b/IMAExtensions.swift
@@ -29,15 +29,13 @@ extension PKAdInfo {
             contentType: ad.contentType,
             adId: ad.adId,
             adSystem: ad.adSystem,
-            height: Int(ad.height),
-            width: Int(ad.width),
+            height: ad.isLinear ? ad.vastMediaHeight : Int(ad.height),
+            width: ad.isLinear ? ad.vastMediaWidth : Int(ad.width),
             totalAds: Int(ad.adPodInfo.totalAds),
             adPosition: Int(ad.adPodInfo.adPosition),
             timeOffset: ad.adPodInfo.timeOffset,
             isBumper: ad.adPodInfo.isBumper,
             podIndex: Int(ad.adPodInfo.podIndex),
-            vastMediaWidth: ad.vastMediaWidth,
-            vastMediaHeight: ad.vastMediaHeight,
-            vastMediaBitrate: ad.vastMediaBitrate)
+            mediaBitrate: ad.vastMediaBitrate)
     }
 }

--- a/IMAPlugin.swift
+++ b/IMAPlugin.swift
@@ -422,7 +422,7 @@ enum IMAState: Int, StateProtocol {
         }
         
         if let bitrate = self.config?.videoBitrate {
-            self.renderingSettings.bitrate = bitrate
+            self.renderingSettings.bitrate = Int(bitrate)
         }
         
         if let mimeTypes = self.config?.videoMimeTypes {

--- a/PlayKit_IMA.podspec
+++ b/PlayKit_IMA.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
         'LIBRARY_SEARCH_PATHS' => '$(inherited) "${PODS_ROOT}"/**' 
   }
 
-  s.dependency 'PlayKit', '~> 3.7.0' + suffix
+  s.dependency 'PlayKit', '~> 3.8.0' + suffix
   s.dependency 'XCGLogger', '~> 6.1.0'
-  s.dependency 'GoogleAds-IMA-iOS-SDK', '3.7.3'
+  s.dependency 'GoogleAds-IMA-iOS-SDK', '3.8.1'
 end


### PR DESCRIPTION
Added to the IMAAd the following vastMediaWidth, vastMediaHeight and vastMediaBitrate which where added in GoogleAds-IMA-iOS-SDK 3.8.1.
Updated to GoogleAds-IMA-iOS-SDK 3.8.1.
Fixed compilation error, change from updating to GoogleAds-IMA-iOS-SDK 3.8.1.
Needs the latest version of PlayKit.