### PR TITLE
IMAPlugin Unowned Self Crash Fix

### DIFF
--- a/IMAPlugin.swift
+++ b/IMAPlugin.swift
@@ -192,20 +192,23 @@ enum IMAState: Int, StateProtocol {
         // notify ads requested
         self.notify(event: AdEvent.AdsRequested(adTagUrl: self.config.adTagUrl))
         // start timeout timer
-        self.requestTimeoutTimer = PKTimer.after(self.requestTimeoutInterval) { [unowned self] _ in
-            if self.adsManager == nil {
+        self.requestTimeoutTimer = PKTimer.after(self.requestTimeoutInterval) { [weak self] _ in
+            
+            guard let strongSelf = self else { return }
+            
+            if strongSelf.adsManager == nil {
                 PKLog.debug("Ads request timed out")
-                switch self.stateMachine.getState() {
-                case .adsRequested: self.delegate?.adsRequestTimedOut(shouldPlay: false)
-                case .adsRequestedAndPlay: self.delegate?.adsRequestTimedOut(shouldPlay: true)
+                switch strongSelf.stateMachine.getState() {
+                case .adsRequested: strongSelf.delegate?.adsRequestTimedOut(shouldPlay: false)
+                case .adsRequestedAndPlay: strongSelf.delegate?.adsRequestTimedOut(shouldPlay: true)
                 default: break // should not receive timeout for any other state
                 }
                 // set state to request failure
-                self.stateMachine.set(state: .adsRequestTimedOut)
+                strongSelf.stateMachine.set(state: .adsRequestTimedOut)
                 
-                self.invalidateRequestTimer()
+                strongSelf.invalidateRequestTimer()
                 // post ads request timeout event
-                self.notify(event: AdEvent.RequestTimedOut())
+                strongSelf.notify(event: AdEvent.RequestTimedOut())
             }
         }
     }


### PR DESCRIPTION
A few months back, me and a few people on the MotorTrend team noticed a crash being reported on Crashlytics.

It was coming from this library in this file in the request timeout handler. I believe there was some kind of a race condition making it possible for the 'self' in the closure to be nil when the closure ran.

We made this change in a forked version of our PlayKit_IMA library, and the crash disappeared from Crashlytics, never to return again.

It appears as though your team has made similar changes to the iOS PlayKit library, fixing crashes that likely resulted from declaring the self in a capture list as unowned. Since self can be nil when the closure gets called, it should be declared weak in the capture list.

I just wanted to point out this issue on the PlayKit_IMA library and how our team fixed it.