### PR TITLE
FEM-2564 Fixed Preroll played again upon replay.

### DIFF
--- a/Sources/IMADAIPlugin.swift
+++ b/Sources/IMADAIPlugin.swift
@@ -72,7 +72,8 @@ import PlayKitUtils
         
         self.messageBus?.addObserver(self, events: [PlayerEvent.ended]) { [weak self] event in
             guard let strongSelf = self else { return }
-            strongSelf.contentComplete()
+            // Do NOT call contentComplete! Because this will reset the IMA correlator, and the UI won't be shown on the ads upon replay.
+            // strongSelf.contentComplete()
             strongSelf.notify(event: AdEvent.AllAdsCompleted())
         }
     }

--- a/Sources/PKIMAVideoDisplay.swift
+++ b/Sources/PKIMAVideoDisplay.swift
@@ -15,7 +15,7 @@ import PlayKit
     private var adDuration: TimeInterval = 0
     
     private var adTimer: Timer?
-    private var adTimerInterval: TimeInterval = 0.2
+    private var adTimerInterval: TimeInterval = 0.5
 
     init(adsDAIPlayerEngineWrapper: AdsDAIPlayerEngineWrapper) {
         self.adsDAIPlayerEngineWrapper = adsDAIPlayerEngineWrapper
@@ -106,7 +106,10 @@ import PlayKit
     // ********************************
     
     @objc private func adTimerFired() {
-        guard let currentPosition = adsDAIPlayerEngineWrapper.playerEngine?.currentPosition else { return }
+        guard let currentPosition = adsDAIPlayerEngineWrapper.playerEngine?.currentPosition else {
+            adCompleted()
+            return
+        }
         adCurrentTime = currentPosition - adStartTime
         if currentPosition > adStartTime, adCurrentTime < adDuration {
             delegate.videoDisplay(self, didProgressWithMediaTime: currentPosition, totalTime: adDuration)
@@ -207,14 +210,15 @@ import PlayKit
         adCurrentTime = 0
         
         delegate.videoDisplayDidLoad(self)
-        delegate.videoDisplayDidStart(self)
-            
-        adTimer = Timer.scheduledTimer(timeInterval: adTimerInterval,
-                                       target: self,
-                                       selector: #selector(adTimerFired),
-                                       userInfo: nil,
-                                       repeats: true)
-        adTimer?.fire()
+        
+        if adTimer == nil {
+            adTimer = Timer.scheduledTimer(timeInterval: adTimerInterval,
+                                           target: self,
+                                           selector: #selector(adTimerFired),
+                                           userInfo: nil,
+                                           repeats: true)
+            adTimer?.fire()
+        }
     }
     
     public func adPaused() {


### PR DESCRIPTION

Fixed "Learn more" and ad countdown not shown after ended player event.
Updated the adTimerInterval to fire every half a second.
Fixed an edge case when the adCompleted is not called and the currentPosition is not available.
Added a check in case the adPlaying is called more than once, not to create the timer again.