### PR TITLE
FEC-10498 IMA - iOS 14 fixes - Update IMA to latest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift
-osx_image: xcode10.2
+osx_image: xcode12
 before_install:
   - gem install cocoapods xcpretty
   - pod repo update

--- a/PlayKit_IMA.podspec
+++ b/PlayKit_IMA.podspec
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/kaltura/playkit-ios-ima.git', :tag => 'v' + s.version.to_s }
   s.swift_version    = '5.0'
   
-  s.ios.deployment_target = '9.0'
-  s.tvos.deployment_target = '9.1'
+  s.ios.deployment_target = '10.0'
+  s.tvos.deployment_target = '10.0'
 
   s.dependency 'PlayKit', '~> 3.11'
   s.dependency 'XCGLogger', '7.0.0'
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.ios.source_files = 'Sources/*.swift', 'Sources/iOS/*.swift'
   s.tvos.source_files = 'Sources/*.swift', 'Sources/tvOS/*.swift'
 
-  s.ios.dependency 'GoogleAds-IMA-iOS-SDK', '3.11.3'
-  s.tvos.dependency 'GoogleAds-IMA-tvOS-SDK', '4.2.1'
+  s.ios.dependency 'GoogleAds-IMA-iOS-SDK', '3.12.1'
+  s.tvos.dependency 'GoogleAds-IMA-tvOS-SDK', '4.3.2'
 
 end

--- a/PlayKit_IMA.podspec
+++ b/PlayKit_IMA.podspec
@@ -15,13 +15,17 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '10.0'
   s.tvos.deployment_target = '10.0'
 
-  s.dependency 'PlayKit', '~> 3.11'
-  s.dependency 'XCGLogger', '7.0.0'
+  s.dependency 'PlayKit', '~> 3.18'
 
   s.ios.source_files = 'Sources/*.swift', 'Sources/iOS/*.swift'
   s.tvos.source_files = 'Sources/*.swift', 'Sources/tvOS/*.swift'
 
   s.ios.dependency 'GoogleAds-IMA-iOS-SDK', '3.13.0'
   s.tvos.dependency 'GoogleAds-IMA-tvOS-SDK', '4.3.2'
+
+  s.xcconfig = {
+### The following is required for Xcode 12 (https://stackoverflow.com/questions/63607158/xcode-12-building-for-ios-simulator-but-linking-in-object-file-built-for-ios)
+    'EXCLUDED_ARCHS[sdk=appletvsimulator*]' => 'arm64'
+  }
 
 end

--- a/PlayKit_IMA.podspec
+++ b/PlayKit_IMA.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.ios.source_files = 'Sources/*.swift', 'Sources/iOS/*.swift'
   s.tvos.source_files = 'Sources/*.swift', 'Sources/tvOS/*.swift'
 
-  s.ios.dependency 'GoogleAds-IMA-iOS-SDK', '3.12.1'
+  s.ios.dependency 'GoogleAds-IMA-iOS-SDK', '3.13.0'
   s.tvos.dependency 'GoogleAds-IMA-tvOS-SDK', '4.3.2'
 
 end

--- a/PlayKit_IMA.podspec
+++ b/PlayKit_IMA.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
 
   s.xcconfig = {
 ### The following is required for Xcode 12 (https://stackoverflow.com/questions/63607158/xcode-12-building-for-ios-simulator-but-linking-in-object-file-built-for-ios)
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64',
     'EXCLUDED_ARCHS[sdk=appletvsimulator*]' => 'arm64'
   }
 

--- a/Sources/IMADAIPlugin.swift
+++ b/Sources/IMADAIPlugin.swift
@@ -196,7 +196,7 @@ import PlayKitUtils
             throw IMADAIPluginRequestError.missingPlayerView
         }
         
-        adDisplayContainer = IMADAIPlugin.createAdDisplayContainer(forView: playerView, withCompanionView: pluginConfig.companionView)
+        adDisplayContainer = IMADAIPlugin.createAdDisplayContainer(forView: playerView, viewController: playerView.findViewController(), withCompanionView: pluginConfig.companionView)
         
         self.adDisplayContainer?.unregisterAllFriendlyObstructions()
         if let videoControlsOverlays = pluginConfig.videoControlsOverlays {

--- a/Sources/IMAPlugin.swift
+++ b/Sources/IMAPlugin.swift
@@ -489,6 +489,11 @@ enum IMAState: Int, StateProtocol, CustomStringConvertible {
         // Only used for dynamic ad insertion (not officially supported)
         case .AD_BREAK_ENDED, .AD_BREAK_STARTED, .CUEPOINTS_CHANGED, .STREAM_LOADED, .STREAM_STARTED, .AD_PERIOD_STARTED, .AD_PERIOD_ENDED, .AD_BREAK_FETCH_ERROR:
             break
+        // This event only fires for tvOS
+        case .ICON_FALLBACK_IMAGE_CLOSED:
+            break
+        case .ICON_TAPPED:
+            break
         @unknown default:
             break
         }

--- a/Sources/IMAPlugin.swift
+++ b/Sources/IMAPlugin.swift
@@ -228,7 +228,7 @@ enum IMAState: Int, StateProtocol, CustomStringConvertible {
             throw IMAPluginRequestError.emptyAdTag
         }
         
-        adDisplayContainer = IMAPlugin.createAdDisplayContainer(forView: playerView, withCompanionView: self.config.companionView)
+        adDisplayContainer = IMAPlugin.createAdDisplayContainer(forView: playerView, viewController: playerView.findViewController(), withCompanionView: self.config.companionView)
         
         self.adDisplayContainer?.unregisterAllFriendlyObstructions()
         if let videoControlsOverlays = self.config?.videoControlsOverlays {

--- a/Sources/UIView+ViewController.swift
+++ b/Sources/UIView+ViewController.swift
@@ -1,0 +1,20 @@
+//
+//  UIView+ViewController.swift
+//  PlayKit_IMA
+//
+//  Created by Nilit Danan on 9/17/20.
+//
+
+import Foundation
+
+extension UIView {
+    func findViewController() -> UIViewController? {
+        if let nextResponder = self.next as? UIViewController {
+            return nextResponder
+        } else if let nextResponder = self.next as? UIView {
+            return nextResponder.findViewController()
+        } else {
+            return nil
+        }
+    }
+}

--- a/Sources/iOS/IMADAIPlugin+AdDisplayContainer.swift
+++ b/Sources/iOS/IMADAIPlugin+AdDisplayContainer.swift
@@ -11,13 +11,13 @@
 import GoogleInteractiveMediaAds
 
 extension IMADAIPlugin {
-    static func createAdDisplayContainer(forView view: UIView, withCompanionView companionView: UIView? = nil) -> IMAAdDisplayContainer {
+    static func createAdDisplayContainer(forView view: UIView, viewController: UIViewController?, withCompanionView companionView: UIView? = nil) -> IMAAdDisplayContainer {
         // Setup ad display container and companion if exists, needs to create a new ad container for each request.
         if let cv = companionView {
             let companionAdSlot = IMACompanionAdSlot(view: companionView, width: Int(cv.frame.size.width), height: Int(cv.frame.size.height))
-            return IMAAdDisplayContainer(adContainer: view, companionSlots: [companionAdSlot!])
+            return IMAAdDisplayContainer(adContainer: view, viewController: viewController, companionSlots: [companionAdSlot!])
         } else {
-            return IMAAdDisplayContainer(adContainer: view, companionSlots: [])
+            return IMAAdDisplayContainer(adContainer: view, viewController: viewController, companionSlots: [])
         }
     }
 }

--- a/Sources/iOS/IMAPlugin+AdDisplayContainer.swift
+++ b/Sources/iOS/IMAPlugin+AdDisplayContainer.swift
@@ -11,13 +11,13 @@
 import GoogleInteractiveMediaAds
 
 extension IMAPlugin {
-    static func createAdDisplayContainer(forView view: UIView, withCompanionView companionView: UIView? = nil) -> IMAAdDisplayContainer {
+    static func createAdDisplayContainer(forView view: UIView, viewController: UIViewController?, withCompanionView companionView: UIView? = nil) -> IMAAdDisplayContainer {
         // Setup ad display container and companion if exists, needs to create a new ad container for each request.
         if let cv = companionView {
             let companionAdSlot = IMACompanionAdSlot(view: companionView, width: Int(cv.frame.size.width), height: Int(cv.frame.size.height))
-            return IMAAdDisplayContainer(adContainer: view, companionSlots: [companionAdSlot!])
+            return IMAAdDisplayContainer(adContainer: view, viewController: viewController, companionSlots: [companionAdSlot!])
         } else {
-            return IMAAdDisplayContainer(adContainer: view, companionSlots: [])
+            return IMAAdDisplayContainer(adContainer: view, viewController: viewController, companionSlots: [])
         }
     }
 }

--- a/Sources/tvOS/IMADAIPlugin+AdDisplayContainer.swift
+++ b/Sources/tvOS/IMADAIPlugin+AdDisplayContainer.swift
@@ -11,8 +11,8 @@
 import GoogleInteractiveMediaAds
 
 extension IMADAIPlugin {
-    static func createAdDisplayContainer(forView view: UIView, withCompanionView companionView: UIView? = nil) -> IMAAdDisplayContainer {
+    static func createAdDisplayContainer(forView view: UIView, viewController: UIViewController?, withCompanionView companionView: UIView? = nil) -> IMAAdDisplayContainer {
         // tvOS doesn't support companionView.
-        return IMAAdDisplayContainer(adContainer: view)
+        return IMAAdDisplayContainer(adContainer: view, viewController: viewController)
     }
 }

--- a/Sources/tvOS/IMAPlugin+AdDisplayContainer.swift
+++ b/Sources/tvOS/IMAPlugin+AdDisplayContainer.swift
@@ -11,8 +11,8 @@
 import GoogleInteractiveMediaAds
 
 extension IMAPlugin {
-    static func createAdDisplayContainer(forView view: UIView, withCompanionView companionView: UIView? = nil) -> IMAAdDisplayContainer {
+    static func createAdDisplayContainer(forView view: UIView, viewController: UIViewController?, withCompanionView companionView: UIView? = nil) -> IMAAdDisplayContainer {
         // tvOS doesn't support companionView.
-        return IMAAdDisplayContainer(adContainer: view)
+        return IMAAdDisplayContainer(adContainer: view, viewController: viewController)
     }
 }

--- a/iOSTestApp/Podfile
+++ b/iOSTestApp/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 target 'iOSTestApp' do
   # Comment the next line if you don't want to use dynamic frameworks

--- a/tvOSTestApp/Podfile
+++ b/tvOSTestApp/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :tvos, '9.1'
+platform :tvos, '10.0'
 
 target 'tvOSTestApp' do
   # Comment the next line if you don't want to use dynamic frameworks

--- a/tvOSTestApp/tvOSTestApp.xcodeproj/project.pbxproj
+++ b/tvOSTestApp/tvOSTestApp.xcodeproj/project.pbxproj
@@ -16,8 +16,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		BCA9AB74B8686DA034A1D196 /* Pods-tvOSTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-tvOSTestApp.debug.xcconfig"; path = "Target Support Files/Pods-tvOSTestApp/Pods-tvOSTestApp.debug.xcconfig"; sourceTree = "<group>"; };
-		CFDDC4EDF151EDF37D8FECB1 /* Pods-tvOSTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-tvOSTestApp.release.xcconfig"; path = "Target Support Files/Pods-tvOSTestApp/Pods-tvOSTestApp.release.xcconfig"; sourceTree = "<group>"; };
+		76003F4EBDE049415E583B80 /* Pods-tvOSTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-tvOSTestApp.release.xcconfig"; path = "Target Support Files/Pods-tvOSTestApp/Pods-tvOSTestApp.release.xcconfig"; sourceTree = "<group>"; };
+		C5CA4BFAFACA6B542507A344 /* Pods-tvOSTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-tvOSTestApp.debug.xcconfig"; path = "Target Support Files/Pods-tvOSTestApp/Pods-tvOSTestApp.debug.xcconfig"; sourceTree = "<group>"; };
 		D2EB83BC23FA9BDD0017DE1E /* tvOSTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = tvOSTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2EB83BF23FA9BDD0017DE1E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D2EB83C123FA9BDD0017DE1E /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -51,8 +51,8 @@
 		C4328C3B019787CE1BC8D190 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				BCA9AB74B8686DA034A1D196 /* Pods-tvOSTestApp.debug.xcconfig */,
-				CFDDC4EDF151EDF37D8FECB1 /* Pods-tvOSTestApp.release.xcconfig */,
+				C5CA4BFAFACA6B542507A344 /* Pods-tvOSTestApp.debug.xcconfig */,
+				76003F4EBDE049415E583B80 /* Pods-tvOSTestApp.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -280,14 +280,13 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = NO;
 				SDKROOT = appletvos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TVOS_DEPLOYMENT_TARGET = 9.1;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Debug;
 		};
@@ -335,25 +334,25 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = NO;
 				SDKROOT = appletvos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				TVOS_DEPLOYMENT_TARGET = 9.1;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
 		};
 		D2EB83CF23FA9BE10017DE1E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BCA9AB74B8686DA034A1D196 /* Pods-tvOSTestApp.debug.xcconfig */;
+			baseConfigurationReference = C5CA4BFAFACA6B542507A344 /* Pods-tvOSTestApp.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = X8RDCFJK95;
+				"EXCLUDED_ARCHS[sdk=appletvsimulator*]" = arm64;
 				INFOPLIST_FILE = tvOSTestApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -363,13 +362,13 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.1;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Debug;
 		};
 		D2EB83D023FA9BE10017DE1E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CFDDC4EDF151EDF37D8FECB1 /* Pods-tvOSTestApp.release.xcconfig */;
+			baseConfigurationReference = 76003F4EBDE049415E583B80 /* Pods-tvOSTestApp.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				CODE_SIGN_STYLE = Automatic;
@@ -383,7 +382,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.1;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Release;
 		};

--- a/tvOSTestApp/tvOSTestApp.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/tvOSTestApp/tvOSTestApp.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreviewsEnabled</key>
+	<false/>
+</dict>
+</plist>

--- a/tvOSTestApp/tvOSTestApp/Info.plist
+++ b/tvOSTestApp/tvOSTestApp/Info.plist
@@ -27,7 +27,6 @@
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>arm64</string>
-		<string>x86_64</string>
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Automatic</string>


### PR DESCRIPTION
Updated iOS and tvOS deployment target to 10.0.
Updated GoogleAds-IMA-iOS-SDK to v3.13.0 and GoogleAds-IMA-tvOS-SDK to v4.3.2.
Updated code accordingly to the IMA SDK changes.