### PR TITLE
FEC-12418 Xcode 14 fixes

### DIFF
--- a/.github/cocoapods_publish.sh
+++ b/.github/cocoapods_publish.sh
@@ -10,4 +10,4 @@ EOF
 
 chmod 0600 ~/.netrc
 
-pod trunk push --verbose
+pod trunk push --verbose --allow-warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
       run: pod repo update
 
     - name: Pod linting
-      run: pod lib lint --fail-fast --verbose
+      run: pod lib lint --fail-fast --verbose --allow-warnings

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,4 +28,4 @@ jobs:
       run: pod repo update
 
     - name: Pod linting
-      run: pod lib lint --fail-fast --verbose
+      run: pod lib lint --fail-fast --verbose --allow-warnings

--- a/Sources/PKIMAVideoDisplay.swift
+++ b/Sources/PKIMAVideoDisplay.swift
@@ -8,9 +8,9 @@ import PlayKit
     
     #if os(tvOS)
     @available(tvOS 14.0, *)
-    private(set) lazy public var nowPlayingSession = MPNowPlayingSession(players: [
-        self.currentPlayer()
-    ])
+    public var nowPlayingSession: MPNowPlayingSession {
+        return MPNowPlayingSession(players: [ self.currentPlayer() ])
+    }
     #endif
     
     func currentPlayer() -> AVPlayer {


### PR DESCRIPTION
FEC-12418
- Stored properties cannot be marked potentially unavailable with '@available' Xcode 14 fixes
- Actions workflows --allow-warnings added to silence DEPLOYMENT_TARGET warnings during pod lint.