### PR TITLE
Support Arm64 for iOS 

### DIFF
--- a/PlayKit_IMA.podspec
+++ b/PlayKit_IMA.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.ios.dependency 'GoogleAds-IMA-iOS-SDK', '3.18.1'
   s.tvos.dependency 'GoogleAds-IMA-tvOS-SDK', '4.6.1'
 
-  s.xcconfig = {
+  s.tvos.xcconfig = {
 ### The following is required for Xcode 12 (https://stackoverflow.com/questions/63607158/xcode-12-building-for-ios-simulator-but-linking-in-object-file-built-for-ios)
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64',
     'EXCLUDED_ARCHS[sdk=appletvsimulator*]' => 'arm64'

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ community@kaltura.com
 ## Requirements
 
 * Xcode 11 or newer
-* iOS/tvOS 11.0+
+* iOS/tvOS 12.0+
 * CocoaPods
 
 ## Installation Instructions

--- a/iOSTestApp/Podfile
+++ b/iOSTestApp/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 target 'iOSTestApp' do
   # Comment the next line if you don't want to use dynamic frameworks

--- a/tvOSTestApp/Podfile
+++ b/tvOSTestApp/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :tvos, '11.0'
+platform :tvos, '12.0'
 
 target 'tvOSTestApp' do
   # Comment the next line if you don't want to use dynamic frameworks


### PR DESCRIPTION
- Updated the pod spec to support ARM64 for iOS targets. _As of version 3.16.3, the GoogleAds-IMA-iOS-SDK now supports Arm64 architecture (silicon simulator support): https://developers.google.com/interactive-media-ads/docs/sdks/ios/client-side/history_
- Bumped readme & test projects -> iOS 12 min as per podpec
- Tested on both test projects with Rosetta enabled/disabled ✅ 
