### PR TITLE
update Ima SDK iOS to : 3.19.1 and tvOS to 4.9.2

### DIFF
--- a/PlayKit_IMA.podspec
+++ b/PlayKit_IMA.podspec
@@ -4,7 +4,7 @@ suffix = '.0000'   # Dev mode
 
 Pod::Spec.new do |s|
   s.name             = 'PlayKit_IMA'
-  s.version          = '1.14.0' + suffix
+  s.version          = '1.15.0' + suffix
   s.author           = { 'Kaltura' => 'community@kaltura.com' }
   s.license          = { :type => 'AGPLv3', :text => 'AGPLv3' }
   s.summary          = 'PlayKit IMA Plugin'
@@ -12,16 +12,16 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/kaltura/playkit-ios-ima.git', :tag => 'v' + s.version.to_s }
   s.swift_version    = '5.0'
   
-  s.ios.deployment_target = '12.0'
-  s.tvos.deployment_target = '12.0'
+  s.ios.deployment_target = '14.0'
+  s.tvos.deployment_target = '14.0'
 
   s.dependency 'PlayKit', '~> 3.22'
 
   s.ios.source_files = 'Sources/*.swift', 'Sources/iOS/*.swift'
   s.tvos.source_files = 'Sources/*.swift', 'Sources/tvOS/*.swift'
 
-  s.ios.dependency 'GoogleAds-IMA-iOS-SDK', '3.18.1'
-  s.tvos.dependency 'GoogleAds-IMA-tvOS-SDK', '4.6.1'
+  s.ios.dependency 'GoogleAds-IMA-iOS-SDK', '3.19.1'
+  s.tvos.dependency 'GoogleAds-IMA-tvOS-SDK', '4.9.2'
 
   s.tvos.xcconfig = {
 ### The following is required for Xcode 12 (https://stackoverflow.com/questions/63607158/xcode-12-building-for-ios-simulator-but-linking-in-object-file-built-for-ios)

--- a/Sources/IMADAIPlugin.swift
+++ b/Sources/IMADAIPlugin.swift
@@ -219,14 +219,14 @@ import PlayKitUtils
             
             request = IMALiveStreamRequest(assetKey: assetKey,
                                            adDisplayContainer: displayContainer,
-                                           videoDisplay: imaPlayerVideoDisplay)
+                                           videoDisplay: imaPlayerVideoDisplay, userContext: nil)
         case .vod:
             guard let contentSourceId = pluginConfig.contentSourceId, let videoId = pluginConfig.videoId else { throw IMADAIPluginRequestError.missingVODData }
             
             request = IMAVODStreamRequest(contentSourceID: contentSourceId,
                                           videoID: videoId,
                                           adDisplayContainer: displayContainer,
-                                          videoDisplay: imaPlayerVideoDisplay)
+                                          videoDisplay: imaPlayerVideoDisplay, userContext: nil)
         }
         
         request.apiKey = pluginConfig.apiKey


### PR DESCRIPTION
  s.ios.dependency 'GoogleAds-IMA-iOS-SDK', '3.19.1'
  s.tvos.dependency 'GoogleAds-IMA-tvOS-SDK', '4.9.2'

update version to 1.15.0

update deployment_target 50 iOS 14.0

fix broken API in the plugin code (IMAVODStreamRequest and IMALiveStreamRequest)